### PR TITLE
Fixed #2

### DIFF
--- a/src/Typing.js
+++ b/src/Typing.js
@@ -123,10 +123,15 @@ class Typing extends Component {
     return new Promise((resolve) => {
       while (cursor.lineNum > text.length - 1 || cursor.charPos < 0) {
         cursor.lineNum -= 1;
+
+        if (cursor.lineNum < 0) {
+          break;
+        }
+
         cursor.charPos = text[cursor.lineNum].length ? text[cursor.lineNum].length - 1 : 0;
       }
 
-      if (cursor.step === 'char') {
+      if (cursor.step === 'char' && cursor.lineNum >= 0) {
         text[cursor.lineNum] = text[cursor.lineNum].substr(0, text[cursor.lineNum].length - 1);
       } else if (cursor.numToErase > 0) {
         text[cursor.lineNum] = '';


### PR DESCRIPTION
When `cursor.lineNum` becomes `< 0` accessing `text[cursor.lineNum]` will return undefined. 
Added checks to see if `cursor.lineNum < 0` to prevent errors.