### PR TITLE
Work around MS Edge problem with weaksets

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -124,7 +124,14 @@ export const getCircularReplacer = () => {
       if (seen.has(value)) {
         return;
       }
-      seen.add(value);
+      try {
+        seen.add(value);
+      } catch (e if e instanceof TypeError) {
+        // The following will break MS Edge:
+        // seen.add(window.location);
+        // See:
+        // https://github.com/Microsoft/ChakraCore/pull/3522
+      }
     }
     return value;
   };


### PR DESCRIPTION
I'm using react-typing-animation with Gatsby 2. I have the following code:

```js
<Typing
  loop={true}
  cursorClassName="heading-cursor"
  className="heading-typing"
>
  {userTypes.slice(0, -1).map((v, idx, arr) => (
    <React.Fragment key={idx}>
      <span>{v}</span>
      <Typing.Reset count={1} delay={1000} />
    </React.Fragment>
  ))}
  {userTypes[userTypes.length - 1]}
  <Typing.Delay ms={1000} />
</Typing>
```
For some reason `window.location` ends up being added to the weakset in the CircularReplacer. On MS Edge this results in a type error that crashes React. See: https://github.com/Microsoft/ChakraCore/pull/3522 and https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12112572/

This PR should work around this issue.