### PR TITLE
onTyping and onStartedTyping callback functionality added

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -20,6 +20,8 @@ class App extends Component {
           startDelay={1000}
           className={styles.title}
           onFinishedTyping={this.showFeatures}
+          onStartedTyping={() => console.log('started typing')}
+          onTyping={(text) => console.log(text)}
         >
           <h1>
             <a href="https://github.com/adamjking3/react-typing-animation">

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,8 @@ const AnimatedTypingComponent = () => (
 |      speed       |   number   |                                            50 (ms)                                             |    no    |
 |    startDelay    |   number   |                                             0 (ms)                                             |    no    |
 |       loop       |  boolean   |                                             false                                              |    no    |
+| onStartedTyping |  function  |                                            () => {}                                            |    no    |
+| onTyping |  function  |                                            () => {}                                            |    no    |
 | onFinishedTyping |  function  |                                            () => {}                                            |    no    |
 
 ### Backspace Component

--- a/src/Typing.js
+++ b/src/Typing.js
@@ -32,7 +32,10 @@ class Typing extends Component {
 
   componentDidMount() {
     this.hasMounted = true;
-    this.resetState().then(() => requestAnimationFrame(this.beginTyping));
+    this.resetState().then(async () => {
+      await this.props.onStartedTyping();
+      requestAnimationFrame(this.beginTyping);
+    })
   }
 
   componentWillUnmount() {
@@ -66,6 +69,7 @@ class Typing extends Component {
     const cursor = { ...this.state.cursor };
 
     if (this.state.toType.length > 0 || cursor.numToErase > 0) {
+      await this.props.onTyping(this.state.text);
       await this.type();
     } else {
       await this.props.onFinishedTyping();
@@ -208,6 +212,8 @@ Typing.propTypes = {
   speed: PropTypes.number,
   startDelay: PropTypes.number,
   loop: PropTypes.bool,
+  onTyping: PropTypes.func,
+  onStartedTyping: PropTypes.func,
   onFinishedTyping: PropTypes.func,
 };
 
@@ -217,6 +223,8 @@ Typing.defaultProps = {
   speed: 50,
   startDelay: 0,
   loop: false,
+  onTyping: () => {},
+  onStartedTyping: () => {},
   onFinishedTyping: () => {},
 };
 


### PR DESCRIPTION
closes issue #30. onStartedTyping will execute before typing starts and onTyping executes for every character typed. Additionally, onTyping also will return the current state of what is typed on the screen, so developers will have the option to execute a function at an exact moment of typing.