### PR TITLE
onBeforeType and onAfterType

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -21,7 +21,8 @@ class App extends Component {
           className={styles.title}
           onFinishedTyping={this.showFeatures}
           onStartedTyping={() => console.log('started typing')}
-          onTyping={(text) => console.log(text)}
+          onBeforeType={(text) => console.log('onBeforeType', text)}
+          onAfterType={(text) => console.log('onAfterType', text)}
         >
           <h1>
             <a href="https://github.com/adamjking3/react-typing-animation">

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@ const AnimatedTypingComponent = () => (
 |    startDelay    |   number   |                                             0 (ms)                                             |    no    |
 |       loop       |  boolean   |                                             false                                              |    no    |
 | onStartedTyping |  function  |                                            () => {}                                            |    no    |
-| onTyping |  function  |                                            () => {}                                            |    no    |
+| onBeforeType |  function  |                                            () => {}                                            |    no    |
+| onAfterType |  function  |                                            () => {}                                            |    no    |
 | onFinishedTyping |  function  |                                            () => {}                                            |    no    |
 
 ### Backspace Component

--- a/src/Typing.js
+++ b/src/Typing.js
@@ -69,8 +69,9 @@ class Typing extends Component {
     const cursor = { ...this.state.cursor };
 
     if (this.state.toType.length > 0 || cursor.numToErase > 0) {
-      await this.props.onTyping(this.state.text);
+      await this.props.onBeforeType(this.state.text);
       await this.type();
+      await this.props.onAfterType(this.state.text);
     } else {
       await this.props.onFinishedTyping();
 
@@ -212,8 +213,9 @@ Typing.propTypes = {
   speed: PropTypes.number,
   startDelay: PropTypes.number,
   loop: PropTypes.bool,
-  onTyping: PropTypes.func,
   onStartedTyping: PropTypes.func,
+  onBeforeType: PropTypes.func,
+  onAfterType: PropTypes.func,
   onFinishedTyping: PropTypes.func,
 };
 
@@ -223,8 +225,9 @@ Typing.defaultProps = {
   speed: 50,
   startDelay: 0,
   loop: false,
-  onTyping: () => {},
   onStartedTyping: () => {},
+  onBeforeType: () => {},
+  onAfterType: () => {},
   onFinishedTyping: () => {},
 };
 


### PR DESCRIPTION
altered onType callback prop to be onBeforeType, and added an onAfterType. Both callbacks will give the current state as arguments to the callback.

```
<Typing
	onBeforeType={(currentText) => {}}
	onAfterType={(currentText) => {}}
/>
```