### PR TITLE
Potential Backspace fix

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -20,9 +20,9 @@ class App extends Component {
           startDelay={1000}
           className={styles.title}
           onFinishedTyping={this.showFeatures}
-          onStartedTyping={() => console.log('started typing')}
-          onBeforeType={(text) => console.log('onBeforeType', text)}
-          onAfterType={(text) => console.log('onAfterType', text)}
+          // onStartedTyping={() => console.log('started typing')}
+          // onBeforeType={(text) => console.log('onBeforeType', text)}
+          // onAfterType={(text) => console.log('onAfterType', text)}
         >
           <h1>
             <a href="https://github.com/adamjking3/react-typing-animation">
@@ -30,6 +30,7 @@ class App extends Component {
             </a>
             <Delay ms={500} />
             <span className={styles.dependencies}>* zero dependencies</span>
+            <Backspace count={10} />
           </h1>
           <Delay ms={1000} />
         </Typing>

--- a/example/App.js
+++ b/example/App.js
@@ -20,9 +20,9 @@ class App extends Component {
           startDelay={1000}
           className={styles.title}
           onFinishedTyping={this.showFeatures}
-          // onStartedTyping={() => console.log('started typing')}
-          // onBeforeType={(text) => console.log('onBeforeType', text)}
-          // onAfterType={(text) => console.log('onAfterType', text)}
+          onStartedTyping={() => console.log('started typing')}
+          onBeforeType={(text) => console.log('onBeforeType', text)}
+          onAfterType={(text) => console.log('onAfterType', text)}
         >
           <h1>
             <a href="https://github.com/adamjking3/react-typing-animation">
@@ -30,7 +30,6 @@ class App extends Component {
             </a>
             <Delay ms={500} />
             <span className={styles.dependencies}>* zero dependencies</span>
-            <Backspace count={10} />
           </h1>
           <Delay ms={1000} />
         </Typing>

--- a/src/Typing.js
+++ b/src/Typing.js
@@ -26,7 +26,7 @@ class Typing extends Component {
       JSON.stringify(children, getCircularReplacer()) !==
         JSON.stringify(this.props.children, getCircularReplacer())
     ) {
-      // this.resetState();
+      this.resetState();
     }
   }
 
@@ -52,7 +52,6 @@ class Typing extends Component {
 
   resetState = async () =>
     this.updateState({
-      text: [],
       toType: extractText(this.props.children),
       cursor: {
         lineNum: 0,
@@ -194,11 +193,11 @@ class Typing extends Component {
 
   render() {
     const { children, className, cursorClassName, hideCursor } = this.props;
-    const { isFinished } = this.state;
+    const { isFinished, text } = this.state;
 
     const cursor = this.props.cursor || <Cursor className={cursorClassName} />;
 
-    const filled = replaceTreeText(children, this.state.text, cursor, isFinished ? true : hideCursor)
+    const filled = replaceTreeText(children, text, cursor, isFinished || hideCursor)
 
     return <div className={className}>{filled}</div>;
   }

--- a/src/Typing.js
+++ b/src/Typing.js
@@ -199,9 +199,6 @@ class Typing extends Component {
     const cursor = this.props.cursor || <Cursor className={cursorClassName} />;
 
     const filled = replaceTreeText(children, this.state.text, cursor, isFinished ? true : hideCursor)
-    // const filled = isFinished
-    //   ? children
-    //   : replaceTreeText(children, this.state.text, cursor, hideCursor)
 
     return <div className={className}>{filled}</div>;
   }

--- a/src/Typing.js
+++ b/src/Typing.js
@@ -26,7 +26,7 @@ class Typing extends Component {
       JSON.stringify(children, getCircularReplacer()) !==
         JSON.stringify(this.props.children, getCircularReplacer())
     ) {
-      this.resetState();
+      // this.resetState();
     }
   }
 
@@ -197,9 +197,11 @@ class Typing extends Component {
     const { isFinished } = this.state;
 
     const cursor = this.props.cursor || <Cursor className={cursorClassName} />;
-    const filled = isFinished
-      ? children
-      : replaceTreeText(children, this.state.text, cursor, hideCursor);
+
+    const filled = replaceTreeText(children, this.state.text, cursor, isFinished ? true : hideCursor)
+    // const filled = isFinished
+    //   ? children
+    //   : replaceTreeText(children, this.state.text, cursor, hideCursor)
 
     return <div className={className}>{filled}</div>;
   }


### PR DESCRIPTION
Proposal for issue #28 

This took a while to figure out what was keeping the backspace functionality from staying in its current state. I had to change two things that seemingly have no repercussions for the app, everything seems to be working just fine still. 

The first thing was on line 200 you were assigning the filled variable back to the normal props.children whenever the Typing component's state isFinished was set to true. Not sure why that was coded like that, but i'm sure there was a reason, at least originally.

The second thing I changed was on line 29, for whatever reason, this line needs to be disabled or the text disappears. Again, commenting it out seemed to have no repercussions for the way the test app worked, and we can take out that entire componentWillReceiveProps lifecycle method if we decide it is unnecessary. 

If either of these things was needed, we can probably figure out some different workarounds, but they're currently where the backspace bug seems to lie. 🐛